### PR TITLE
Front matter config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shodo_ssg"
-version = "0.0.dev1"
+version = "0.0.dev2"
 description = "A Python-based static site generator for building sites from Markdown and JSON files"
 authors = [{name = "Ryan Phillips"}]
 license = {text = "MIT"}

--- a/shodo_ssg/project_template/src/theme/markdown/articles/blog/first-blog.md
+++ b/shodo_ssg/project_template/src/theme/markdown/articles/blog/first-blog.md
@@ -1,3 +1,12 @@
+@frontmatter
+{
+    "title": "This is the first Blog Title!",
+    "category": "general",
+    "body_class": "blog-page first-blog",
+    "description": "This is the first blog description"
+}
+@endfrontmatter
+
 ## First Blog Post
 This page was automatically generated as html by creating a markdown file in the `markdown/articles` directory! It's a perfect way to quickly publish blog posts, articles, or updates. 
 

--- a/shodo_ssg/project_template/src/theme/views/articles/layout.jinja
+++ b/shodo_ssg/project_template/src/theme/views/articles/layout.jinja
@@ -1,3 +1,13 @@
+@frontmatter
+{
+    "title": "This is the default blog layout!",
+    "author": "Shodo SSG",
+    "body_class": "blog-page",
+    "body_id": "blog-page-container",
+    "description": "This is the default blog template"
+}
+@endfrontmatter
+
 <div class="container">
 <header class="page-header">
     <h1 class="page-header__title">This is the root article layout</h1>

--- a/shodo_ssg/project_template/src/theme/views/home.jinja
+++ b/shodo_ssg/project_template/src/theme/views/home.jinja
@@ -1,3 +1,16 @@
+@frontmatter
+{
+    "title": "Shodo - A Static Site Generator - Home",
+    "description": "Home page of the site",
+    "keywords": ["home", "site", "example"],
+    "author": "Your Name",
+    "head_extra": [
+        "<!--<link rel='stylesheet' href='/static/css/custom.css'>-->",
+        "<!--<script src='/static/js/custom.js'></script>-->"
+    ]
+}
+@endfrontmatter
+
 <div class="container">
 <header class="site-header">
     <img class="site-header__icon" height="150" width="150" src="/static/images/calligraphy-icon.svg" alt="Calligraphy pen writing on scroll">

--- a/shodo_ssg/project_template/src/theme/views/pages/blog.jinja
+++ b/shodo_ssg/project_template/src/theme/views/pages/blog.jinja
@@ -1,3 +1,10 @@
+@frontmatter
+{
+    "title": "Check out the Blog Posts",
+    "description": "Archive for example blog posts"
+}
+@endfrontmatter
+
 <div class = "container">
 <header class="page-header">
     <h1 class="page-header__title">Check out the Blog Posts</h1>

--- a/shodo_ssg/project_template/src/theme/views/pages/linked_page.jinja
+++ b/shodo_ssg/project_template/src/theme/views/pages/linked_page.jinja
@@ -1,3 +1,10 @@
+@frontmatter
+{
+    "title": "This is a linked page!",
+    "description": "Just a miscellaneous page"
+}
+@endfrontmatter
+
 <div class="container">
 <header class="page-header">
     <h1 class="page-header__title">This is a linked page!</h1>

--- a/shodo_ssg/project_template/src/theme/views/pages/nested-route/double-nested-route.jinja
+++ b/shodo_ssg/project_template/src/theme/views/pages/nested-route/double-nested-route.jinja
@@ -1,3 +1,10 @@
+@frontmatter
+{
+    "title": "This page is nested!",
+    "description": "This is a nested page template"
+}
+@endfrontmatter
+
 <div class="container">
 <header class="page-header">
     <h1 class="page-header__title">This page is nested!</h1>

--- a/shodo_ssg/project_template/src/theme/views/pages/nested-route/double-nested-route/triple-nested-route.jinja
+++ b/shodo_ssg/project_template/src/theme/views/pages/nested-route/double-nested-route/triple-nested-route.jinja
@@ -1,11 +1,18 @@
+@frontmatter
+{
+    "title": "Another Nested Page",
+    "description": "This is a nested page template"
+}
+@endfrontmatter
+
 <div class="container">
-<header class="page-header">
-    <h1 class="page-header__title">And now this page is even more nested!</h1>
-</header>
-<main>
-<p>
-    You can create as many nested page directories as you would like!
-</p>
-</main>
-<footer><a href="/">Back to Home</a></footer>
+    <header class="page-header">
+        <h1 class="page-header__title">And now this page is even more nested!</h1>
+    </header>
+    <main>
+        <p>
+            You can create as many nested page directories as you would like!
+        </p>
+    </main>
+    <footer><a href="/">Back to Home</a></footer>
 </div>

--- a/shodo_ssg/project_template/src/theme/views/partials/another_template.jinja
+++ b/shodo_ssg/project_template/src/theme/views/partials/another_template.jinja
@@ -1,3 +1,13 @@
+@frontmatter
+{
+    "head_extra": [
+        "<!--<link rel='stylesheet' href='/static/css/custom.css'>-->",
+        "<!--<link rel='stylesheet' href='/static/css/another.css'>-->",
+        "<!--<script src='/static/js/custom.js'></script>-->"
+    ]
+}
+@endfrontmatter
+
 <h2>Partial Templates</h2>
 <p>This is another jinja2 template, separate from the main layout!</p>
 <p>

--- a/shodo_ssg/template_handler.py
+++ b/shodo_ssg/template_handler.py
@@ -1,10 +1,12 @@
-""" 
-This module is responsible for handling the template environment as well as 
+"""
+This module is responsible for handling the template environment as well as
 rendering the Jinja2 templates as html
 """
 
 import logging
 import os
+import re
+from typing import Optional
 from jinja2 import (
     Environment,
     FileSystemLoader,
@@ -58,6 +60,13 @@ class TemplateHandler:
             # Set the markdown pages upon class instantiation
             self._md_pages = self.markdown_loader.load_pages()
 
+            for md_page in self._md_pages:
+                front_matter = self.get_front_matter(os.path.abspath(md_page["path"]))
+                if not front_matter:
+                    front_matter = {}
+                # Add the front matter to the md_page
+                md_page["front_matter"] = front_matter
+
         return self._md_pages.copy()
 
     def update_render_arg(self, key, value):
@@ -88,25 +97,249 @@ class TemplateHandler:
         self,
         styles_link="/static/styles/main.css",
         favicon_link='<link rel="icon" type="image/x-icon" href="/favicon.ico">',
+        front_matter: Optional[dict] = None,
     ):
         """
         Generate the HTML head section for a document, including opening body tag.
         """
-        return (
-            f"""
+        global_metadata: dict = self.render_args.get("metadata", {})
+        if front_matter is None:
+            front_matter = {}
+
+        # Merge global metadata with front matter, with front_matter taking precedence
+        head_content = self._merge_head_data(front_matter, global_metadata)
+
+        # Extract the "lang", "body_id", and "body_class" properties and
+        # remove them from the dictionary
+        lang = head_content.pop("lang", "en")
+        body_id = head_content.pop("body_id", None)
+        body_class = head_content.pop("body_class", None)
+
+        # Format the properties of the head content as HTML tags
+        head_content_tags = self._format_head_data_as_html(head_content)
+
+        # Remove empty tags "" from the dictionary
+        head_content_tags = {k: v for k, v in head_content_tags.items() if v != ""}
+        # Join the tags into a single string
+        head_content_html = "\n".join(head_content_tags.values())
+
+        head_html = f"""
         <!DOCTYPE html>
-        <html lang="en">
+        <html lang="{lang}">
         <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>{ self.render_args["metadata"]["title"] }</title>
+            {head_content_html}
             {favicon_link}
             <link href="{styles_link}" rel="stylesheet" />
         </head>
-        <body>
-        """.strip()
-            + "\n"
-        )
+        <body
+        """
+        if body_id:
+            head_html += f' id="{body_id}"'
+        if body_class:
+            head_html += f' class="{body_class}"'
+        head_html += ">"
+        head_html = head_html.strip() + "\n"
+
+        return head_html
+
+    def _format_head_data_as_html(self, head_content: dict) -> dict:
+        """
+        Format the properties of the head content as HTML tags.
+        """
+        # Format the properties of the head content as HTML tags
+        formatted_head_content = {
+            "charset": f'<meta charset="{head_content["charset"]}">',
+            "viewport": '<meta name="viewport" content="width=device-width, initial-scale=1.0">',
+            "title": f'<title>{head_content["title"]}</title>',
+            "description": (
+                f'<meta name="description" content="{head_content["description"]}">'
+                if head_content["description"]
+                else ""
+            ),
+            "keywords": (
+                f'<meta name="keywords" content="{",".join(head_content["keywords"])}">'
+                if isinstance(head_content["keywords"], list)
+                else (
+                    f'<meta name="keywords" content="{head_content["keywords"]}">'
+                    if head_content["keywords"]
+                    else ""
+                )
+            ),
+            "author": (
+                f'<meta name="author" content="{head_content["author"]}">'
+                if head_content["author"]
+                else ""
+            ),
+            "theme_color": (
+                f'<meta name="theme-color" content="{head_content["theme_color"]}">'
+                if head_content["theme_color"]
+                else ""
+            ),
+            "og_image": (
+                f'<meta property="og:image" content="{head_content["og_image"]}">'
+                if head_content["og_image"]
+                else ""
+            ),
+            "og_image_alt": (
+                f'<meta property="og:image:alt" content="{head_content["og_image_alt"]}">'
+                if head_content["og_image_alt"]
+                else ""
+            ),
+            "og_title": (
+                f'<meta property="og:title" content="{head_content["og_title"]}">'
+                if head_content["og_title"]
+                else ""
+            ),
+            "og_description": (
+                f'<meta property="og:description" content="{head_content["og_description"]}">'
+                if head_content["og_description"]
+                else ""
+            ),
+            "og_url": (
+                f'<meta property="og:url" content="{head_content["og_url"]}">'
+                if head_content["og_url"]
+                else ""
+            ),
+            "og_type": (
+                f'<meta property="og:type" content="{head_content["og_type"]}">'
+                if head_content["og_type"]
+                else ""
+            ),
+            "og_site_name": (
+                f'<meta property="og:site_name" content="{head_content["og_site_name"]}">'
+                if head_content["og_site_name"]
+                else ""
+            ),
+            "og_locale": (
+                f'<meta property="og:locale" content="{head_content["og_locale"]}">'
+                if head_content["og_locale"]
+                else ""
+            ),
+            "canonical": (
+                f'<link rel="canonical" href="{head_content["canonical"]}">'
+                if head_content["canonical"]
+                else ""
+            ),
+            "google_font_link": (
+                f"""
+                <link rel="preconnect" href="https://fonts.googleapis.com">
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+                <link href="{head_content["google_font_link"]}" rel="stylesheet">
+                """
+                if head_content["google_font_link"]
+                else ""
+            ),
+            "preconnects": (
+                "\n".join(
+                    [
+                        f'<link rel="preconnect" href="{link}">'
+                        for link in head_content["preconnects"]
+                    ]
+                )
+                if isinstance(head_content["preconnects"], list)
+                else (
+                    f'<link rel="preconnect" href="{head_content["preconnects"]}">'
+                    if head_content["preconnects"]
+                    else ""
+                )
+            ),
+            "stylesheets": (
+                "\n".join(
+                    [
+                        f'<link rel="stylesheet" href="{sheet}">'
+                        for sheet in head_content["stylesheets"]
+                    ]
+                )
+                if isinstance(head_content["stylesheets"], list)
+                else (
+                    f'<link rel="stylesheet" href="{head_content["stylesheets"]}">'
+                    if head_content["stylesheets"]
+                    else ""
+                )
+            ),
+            "robots": (
+                f'<meta name="robots" content="{head_content["robots"]}">'
+                if head_content["robots"]
+                else ""
+            ),
+            "head_extra": (
+                "\n".join(head_content["head_extra"])
+                if isinstance(head_content["head_extra"], list)
+                else (
+                    f'{head_content["head_extra"]}'
+                    if head_content["head_extra"]
+                    else ""
+                )
+            ),
+        }
+        return formatted_head_content
+
+    def _merge_head_data(self, front_matter: dict, global_metadata: dict):
+        """
+        Format the head data for the HTML document. This includes merging
+        global metadata with front matter and generating the HTML head section.
+        """
+        # Merge global metadata with front matter, with front_matter taking precedence
+        metadata = {
+            "title": front_matter.get(
+                "title", global_metadata.get("title", "Shodo SSG")
+            ),
+            "lang": front_matter.get("lang", global_metadata.get("lang", "en")),
+            "charset": front_matter.get(
+                "charset", global_metadata.get("charset", "UTF-8")
+            ),
+            "description": front_matter.get(
+                "description", global_metadata.get("description", "")
+            ),
+            "keywords": front_matter.get(
+                "keywords", global_metadata.get("keywords", "")
+            ),
+            "author": front_matter.get("author", global_metadata.get("author", "")),
+            "theme_color": front_matter.get(
+                "theme_color", global_metadata.get("theme_color", "")
+            ),
+            "og_image": front_matter.get(
+                "og_image", global_metadata.get("og_image", "")
+            ),
+            "og_image_alt": front_matter.get(
+                "og_image_alt", global_metadata.get("og_image_alt", "")
+            ),
+            "og_title": front_matter.get(
+                "og_title", global_metadata.get("og_title", "")
+            ),
+            "og_description": front_matter.get(
+                "og_description", global_metadata.get("og_description", "")
+            ),
+            "og_url": front_matter.get("og_url", global_metadata.get("og_url", "")),
+            "og_type": front_matter.get("og_type", global_metadata.get("og_type", "")),
+            "og_site_name": front_matter.get(
+                "og_site_name", global_metadata.get("og_site_name", "")
+            ),
+            "og_locale": front_matter.get(
+                "og_locale", global_metadata.get("og_locale", "")
+            ),
+            "canonical": front_matter.get(
+                "canonical", global_metadata.get("canonical", "")
+            ),
+            "google_font_link": front_matter.get(
+                "google_font_link", global_metadata.get("google_font_link", "")
+            ),
+            "preconnects": front_matter.get(
+                "preconnects", global_metadata.get("preconnects", [])
+            ),
+            "stylesheets": front_matter.get(
+                "stylesheets", global_metadata.get("stylesheets", [])
+            ),
+            "robots": front_matter.get("robots", global_metadata.get("robots", "")),
+            "head_extra": front_matter.get(
+                "head_extra", global_metadata.get("head_extra", "")
+            ),
+            "body_id": front_matter.get("body_id", global_metadata.get("body_id", "")),
+            "body_class": front_matter.get(
+                "body_class", global_metadata.get("body_class", "")
+            ),
+        }
+        return metadata
 
     def _get_doc_tail(self, script_link="/static/scripts/main.js"):
         """
@@ -119,19 +352,26 @@ class TemplateHandler:
         </html>
         """.strip()
 
-    def _write_html_from_template(self, template_name, destination_dir):
+    def _write_html_from_template(
+        self, template_name, destination_dir, front_matter: Optional[dict] = None
+    ):
         """
         Render a template with the provided arguments and write the output to a file.
         """
         self._log_info(template_name, destination_dir)
         template = self.get_template(template_name)
+        template_path = os.path.abspath(template.filename)
+        if front_matter is None:
+            front_matter = self.get_front_matter(template_path)
         with open(destination_dir, "w", encoding="utf-8") as output_file:
             output_file.write(
-                self._get_doc_head()
+                self._get_doc_head(front_matter=front_matter)
                 + template.render(self.render_args)
                 + "\n"
                 + self._get_doc_tail()
             )
+
+        self.clear_front_matter(destination_dir)
 
     def write_home_template(self):
         """
@@ -180,9 +420,22 @@ class TemplateHandler:
                 md_page["url_segment"].strip("/"),
                 md_page["name"].strip("/"),
             )
+
+            self.update_render_arg("article", md_page["html"])
+
+            front_matter = md_page["front_matter"]
+
+            if front_matter:
+                # Don't write the template if 'draft' is set in front matter
+                is_draft = front_matter.get("draft", False)
+                if isinstance(is_draft, str) and (
+                    is_draft.lower() == "true" or is_draft == "1"
+                ):
+                    continue
+
             if not os.path.exists(build_path):
                 os.makedirs(build_path)
-            self.update_render_arg("article", md_page["html"])
+
             self._write_html_from_template(layout_template, f"{build_path}/index.html")
 
     def get_md_layout_template(self, url_segment: str):
@@ -195,17 +448,138 @@ class TemplateHandler:
         if not url_segment:
             return "articles/layout.jinja"
         template_path = os.path.join("articles", url_segment.strip("/"), "layout.jinja")
-        src_view_path = "/" + os.path.join(self.root_path, "src/theme/views/").strip("/")
+        src_view_path = "/" + os.path.join(self.root_path, "src/theme/views/").strip(
+            "/"
+        )
         if os.path.exists(f"{src_view_path}/{template_path}"):
             return template_path
         segments = url_segment.strip("/").split("/")
         segments.pop()
         return self.get_md_layout_template("/".join(segments))
 
+    def get_front_matter(self, file_path):
+        """
+        Retrieves the front matter from either a markdown or jinja file. The front matter is
+        the metadata that is used to populate the render arguments. It is a JSON object that
+        is enclosed by `@frontmatter` at the beginning of the object and `@endfrontmatter` at
+        the end of the front matter.
+        """
+        content = ""
+        if (
+            file_path.endswith(".jinja")
+            or file_path.endswith(".j2")
+            or file_path.endswith(".jinja2")
+        ):
+            # If the file is a jinja template, we need to render it so
+            # that front matter from included templates is also included
+            # in the front matter
+            template_name = os.path.basename(file_path)
+            template = self.get_template(template_name)
+            content = template.render(self.render_args)
+        else:
+            with open(file_path, "r", encoding="utf-8") as file:
+                content = file.read()
+                content = content.lstrip()
+
+        pattern = r"@frontmatter\s*(.*?)\s*@endfrontmatter"
+        pattern = re.compile(pattern, re.DOTALL)
+        front_matters = pattern.findall(content)
+        if front_matters:
+            # If the front matter is a list, merge them into a single dict,
+            # with the last one taking precedence
+            if isinstance(front_matters, list) and len(front_matters) >= 1:
+                combined_front_matter = {}
+                for fm in front_matters:
+                    fm = fm.replace("@frontmatter", "").replace("@endfrontmatter", "")
+                    fm = fm.strip()
+                    # If parsable json, return as dict
+                    if fm.startswith("{") and fm.endswith("}"):
+                        fm = self.json_loader.json_to_dict(fm)
+                        if isinstance(fm, dict):
+                            combined_front_matter.update(fm)
+
+                # If the front matter is a dictionary, return it
+                if isinstance(combined_front_matter, dict):
+                    return combined_front_matter
+
+        return None
+
+    def clear_front_matter(
+        self, file_path: Optional[str] = None, content: Optional[str] = None
+    ):
+        """
+        Strips the front matter from the rendered html file. The front matter is a JSON object
+        that is enclosed by the tags `@frontmatter` and `@endfrontmatter`. In the html files
+        that were generated from markdown files, the front matter tags are also enclosed in
+        '<p>' tags. This function removes the front matter and the enclosing '<p>' tags if they
+        exist. If a file path is provided, the function will write the content back to the file
+        after removing the front matter. If no content is provided instead of a file path, the
+        function will return the content with the front matter removed.
+        """
+        front_matters = None
+
+        if content is None and file_path is not None:
+            with open(file_path, "r", encoding="utf-8") as file:
+                content = file.read()
+
+        if "<p>@frontmatter" in content:
+            pattern = r"(<p>@frontmatter\s*.*?\s*@endfrontmatter</p>)"
+            pattern = re.compile(pattern, re.DOTALL)
+            front_matters = pattern.findall(content)
+            if front_matters:
+                for fm in front_matters:
+                    fm = fm.strip()
+                    content = content.replace(fm, "")
+
+        if "@frontmatter" in content:
+            pattern = r"(@frontmatter\s*.*?\s*@endfrontmatter)"
+            pattern = re.compile(pattern, re.DOTALL)
+            front_matters = pattern.findall(content)
+            if front_matters:
+                for fm in front_matters:
+                    fm = fm.strip()
+                    content = content.replace(fm, "")
+        if front_matters and file_path:
+            with open(file_path, "w", encoding="utf-8") as file:
+                file.write(content)
+
+        return content
+
+    def _format_md_page_data(self, md_page: dict) -> dict:
+        """
+        Format the markdown page data for rendering. This includes extracting
+        the front matter and content from the markdown page. Used for rendering
+        a list of articles/posts in a template with the shodo_get_articles function.
+        """
+        post = {}
+        post["file_name"] = md_page["name"]
+        post["path"] = md_page["url_segment"] + md_page["name"]
+
+        front_matter = md_page["front_matter"]
+
+        if not isinstance(front_matter, dict):
+            front_matter = {}
+
+        post["title"] = front_matter.get("title", "")
+        post["description"] = front_matter.get("description", "")
+        post["summary"] = front_matter.get("summary", "")
+        post["keywords"] = front_matter.get("keywords", [])
+        post["author"] = front_matter.get("author", "")
+        post["category"] = front_matter.get("category", "")
+        post["tags"] = front_matter.get("tags", [])
+        post["date"] = front_matter.get("date", "")
+        post["draft"] = front_matter.get("draft", False)
+        post["image"] = front_matter.get("image", "")
+        post["image_alt"] = front_matter.get("image_alt", "")
+        post["content"] = md_page["html"]
+        post["modified"] = front_matter.get("modified", "")
+
+        return post
+
     def write(self):
         """
         Writes the root index.html and any linked html pages using the provided render arguments.
         """
+        self.write_article_pages()
         self.write_home_template()
         self.write_linked_template_pages()
-        self.write_article_pages()


### PR DESCRIPTION
# Front Matter Configuration

Closes #13 

This PR adds support for customizing specific metadata for each page using the `@frontmatter` and `@endfrontmatter` tags at the beginning of a Jinja template or markdown file, with a json object inside of the tags. The current supported variables are:


`lang`: The language metadata for the page `<head>`
`title`: The title metadata for the page `<head>`
`charset`: The charset metadata for the page `<head>`
`description`: The description metadata for the page `<head>`
`keywords`: Keyword metadata for the page `<head>`
`author`: Author metadata for the page `<head>`
`og_image`: Open graph image metadata for the page `<head>`
`og_image_alt`: Open graph image alt metadata for the page `<head>`
`og_title`: Open graph title metadata for the page `<head>`
`og_description`: Open graph description metadata for the page `<head>`
`og_url`: Open graph URL metadata for the page `<head>`
`og_type`: Open graph type metadata for the page `<head>`
`og_site_name`: Open graph site name metadata for the page `<head>`
`og_locale`: Open graph locale metadata for the page `<head>`
`canonical`: Canonical URL metadata for the page `<head>`
`google_font_link`: URL link to import google font. Automatically creates the preconnect link tags
`preconnects`: Any urls that should be preconnected to in the `<head>` for the page. Generates the `<link>` tags
`stylesheets`: Any external stylesheets that should be included on the page
`robots`: Robots metadata for the page `<head>`
`head_extra`: Custom raw string that will be included in the `<head>`. Should be a valid tag, such as `<script>` or `<link>`
`body_id`: The id attribute for the `<body>` tag
`body_class`: The class attribute for the `<body>` tag

Additionally, these variables can be used on markdown files:
`summary`: Short version of content
`category`: Taxonomy to categorize the article (one)
`tags`: Additional taxonomy for the article (many)
`date`: Publish date as UTC timestamp
`draft`: Boolean indicating whether article is a draft. Defaults to "false" if not included
`modified`: Option to add a UTC timestamp when an article has been edited

### Example:
```
@frontmatter
{
    "title": "Shodo - A Static Site Generator - Home",
    "description": "Home page of the site",
    "keywords": ["home", "site", "example"],
    "author": "Your Name",
    "head_extra": [
        "<link rel='stylesheet' href='/static/css/custom.css'>",
        "<script src='/static/js/custom.js'></script>"
    ]
}
@endfrontmatter
```