### PR TITLE
Fixes 0.0.1a3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shodo_ssg"
-version = "0.0.1a2"
+version = "0.0.1a3"
 description = "A Python-based static site generator for building sites from Markdown and JSON files"
 authors = [{name = "Ryan Phillips", email = "ryanphillipssoftware@gmail.com"}]
 license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 keywords = ["shodo", "static site generator", "ssg", "blog", "rss"]
 requires-python = ">=3.9"

--- a/shodo_ssg/template_handler.py
+++ b/shodo_ssg/template_handler.py
@@ -68,7 +68,9 @@ class TemplateHandler:
         template = self.get_template(template_name)
         template_path = os.path.abspath(template.filename)
         if front_matter is None:
-            front_matter = self.get_front_matter(template_path)
+            front_matter = self.get_front_matter(
+                file_path=template_path, template_name=template_name
+            )
 
         file_type = front_matter.get("file_type", "html")
         suffix = "/index.html"
@@ -216,7 +218,7 @@ class TemplateHandler:
         segments.pop()
         return self.get_md_layout_template("/".join(segments))
 
-    def get_front_matter(self, file_path):
+    def get_front_matter(self, file_path="", template_name=""):
         """
         Retrieves the front matter from either a markdown or jinja file. The front matter is
         the metadata that is used to populate the render arguments. It is a JSON object that
@@ -224,7 +226,7 @@ class TemplateHandler:
         the end of the front matter.
         """
         content = ""
-        if (
+        if template_name and (
             file_path.endswith(".jinja")
             or file_path.endswith(".j2")
             or file_path.endswith(".jinja2")
@@ -232,7 +234,6 @@ class TemplateHandler:
             # If the file is a jinja template, we need to render it so
             # that front matter from included templates is also included
             # in the front matter
-            template_name = os.path.basename(file_path)
             template = self.get_template(template_name)
             # Temporarily suppress missing variable errors
             self.pagination_handler.set_default_pagination_variables()

--- a/shodo_ssg/template_handler.py
+++ b/shodo_ssg/template_handler.py
@@ -72,6 +72,11 @@ class TemplateHandler:
                 file_path=template_path, template_name=template_name
             )
 
+        is_draft = front_matter.get("draft", False) in [True, "true", "1", "True", 1]
+
+        if is_draft:
+            return
+
         file_type = front_matter.get("file_type", "html")
         suffix = "/index.html"
         if file_type == "xml":
@@ -182,6 +187,8 @@ class TemplateHandler:
             if front_matter:
                 # Don't write the template if 'draft' is set in front matter
                 is_draft = front_matter.get("draft", False)
+                if isinstance(is_draft, bool) and is_draft:
+                    continue
                 if isinstance(is_draft, str) and (
                     is_draft.lower() == "true" or is_draft == "1"
                 ):

--- a/tests/project_template/src/views/articles/blog/subject/layout.jinja
+++ b/tests/project_template/src/views/articles/blog/subject/layout.jinja
@@ -1,3 +1,13 @@
+@frontmatter
+{
+    "title": "Blog Subject Layout",
+    "author": "Shodo SSG Nested Layout",
+    "body_class": "blog-subject-page",
+    "body_id": "blog-subject-page-container",
+    "description": "This is the subject-specific blog template"
+}
+@endfrontmatter
+
 <div class="container">
 <header class="page-header">
     <h1 class="page-header__title">This is the layout defined for a specific subdirectory</h1>

--- a/tests/test_template_handler.py
+++ b/tests/test_template_handler.py
@@ -356,3 +356,42 @@ def test_template_handler_write_outputs_frontmatter_with_correct_heirarchy(
     assert (
         '<meta name="description" content="Home page of the site">' in index_contents
     ), "Metadata should be pulled from the homepage frontmatter"
+
+
+def test_template_handler_write_outputs_article_layout_frontmatter_with_correct_heirarchy(
+    template_handler_dependencies,
+):  # pylint: disable=redefined-outer-name
+    """
+    Test that the write method output of the TemplateHandler class overwrites the
+    global config with the article layout frontmatter.
+    """
+    settings, root_layout_builder, pagination_handler, api = (
+        template_handler_dependencies
+    )
+    template_handler = TemplateHandler(
+        settings, root_layout_builder, pagination_handler, api
+    )
+
+    if not os.path.exists(template_handler.build_dir):
+        os.makedirs(template_handler.build_dir)
+
+    template_handler.write()
+
+    build_path = os.path.join(
+        template_handler.build_dir,
+        "blog",
+        "subject",
+        "second-blog",
+    )
+
+    assert os.path.exists(build_path)
+    assert os.path.exists(f"{build_path}/index.html")
+    with open(f"{build_path}/index.html", "r", encoding="utf-8") as page_file:
+        page_contents = page_file.read()
+    assert page_contents
+    assert "<!DOCTYPE html>" in page_contents
+    assert (
+        'id="blog-subject-page-container"' in page_contents
+    ), "Body attributes should be pulled from the nested article layout frontmatter"
+
+    assert '<meta name="author" content="Shodo SSG Nested Layout">' in page_contents


### PR DESCRIPTION
This pull request introduces improvements to front matter handling in templates, enhances draft article exclusion logic, and adds new tests to ensure correct metadata inheritance from nested layouts. The changes also update the project metadata and test coverage for layout front matter.

**Bug fix: Nested template layout frontmatter**
* There was an issue introduced after the latest big refactor where frontmatter was always being grabbed from the root layout template in `/views/articles` instead of the one correctly mapped to the given markdown file. This was because `os.path.basename` was incorrectly being used to get the template name at the last step before retrieving frontmatter, so it would always be `layout.jinja` instead of `blog/layout.jinja` or `subject/layout.jinja`, etc. This is now resolved by passing the original (correct) template name that was extracted earlier in the process to the `get_front_matter` method.

**Front matter and draft handling improvements:**

* Improved draft exclusion logic in `TemplateHandler`: Articles and templates marked as drafts (via the `draft` field in front matter, supporting multiple representations like `True`, `"true"`, `"1"`, etc.) are now reliably excluded from output. [[1]](diffhunk://#diff-d247c5898fc7c580470e862cee413f957fc359bc261119e754680ccaac3925cfL71-R78) [[2]](diffhunk://#diff-d247c5898fc7c580470e862cee413f957fc359bc261119e754680ccaac3925cfR190-R191)
* Enhanced front matter retrieval: The `get_front_matter` method now accepts both `file_path` and `template_name` parameters, improving its ability to extract metadata from both markdown and Jinja templates, especially for nested or included templates.

**Project metadata and test coverage:**

* Added license file to project metadata and updated version to `0.0.1a3` in `pyproject.toml`.
* Added front matter to the nested layout template `layout.jinja` for more explicit metadata inheritance in nested articles.
* Added a new test to verify that article pages correctly inherit front matter (such as `author` and `body_id`) from their nested layout templates, ensuring metadata is properly reflected in the generated HTML.