### PR TITLE
Minor 0.0.1a4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shodo_ssg"
-version = "0.0.1a3"
+version = "0.0.1a4"
 description = "A Python-based static site generator for building sites from Markdown and JSON files"
 authors = [{name = "Ryan Phillips", email = "ryanphillipssoftware@gmail.com"}]
 license = "MIT"

--- a/shodo_ssg/html_root_layout_builder.py
+++ b/shodo_ssg/html_root_layout_builder.py
@@ -12,7 +12,6 @@ class HTMLRootLayoutBuilder:
         self,
         render_args: dict,
         styles_link="/static/styles/main.css",
-        favicon_link='<link rel="icon" type="image/x-icon" href="/favicon.ico">',
         front_matter: Optional[dict] = None,
     ):
         """
@@ -44,7 +43,6 @@ class HTMLRootLayoutBuilder:
         <html lang="{lang}">
         <head>
             {head_content_html}
-            {favicon_link}
             <link href="{styles_link}" rel="stylesheet" />
         </head>
         <body

--- a/shodo_ssg/project_template/src/store/config.json
+++ b/shodo_ssg/project_template/src/store/config.json
@@ -4,7 +4,10 @@
             "title": "Shodo - Static Site Generator",
             "description": "Shodo is a static site generator that uses Markdown and JSON files to generate a static site.",
             "author": "Shodo",
-            "google_font_link": "https://fonts.googleapis.com/css2?family=Momo+Trust+Display&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap"
+            "google_font_link": "https://fonts.googleapis.com/css2?family=Momo+Trust+Display&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap",
+            "head_extra": [
+                "<link rel='icon' type='image/x-icon' href='/favicon.ico'>"
+            ]
         },
         "url_origin": "https://my-shodo-site.dev",
         "timezone": "America/Chicago"

--- a/tests/project_template/src/store/config.json
+++ b/tests/project_template/src/store/config.json
@@ -8,6 +8,7 @@
                 "<script type='application/ld+json'>{ \"@context\": \"https://schema.org\", \"@type\": \"Article\", \"headline\": \"LD+JSON Article\", \"description\": \"This article has ld+json in head extra.\" }</script>",
                 "<script type='application/ld+json'>{ '@context': 'https://schema.org', '@type': 'Article', 'headline': 'LD+JSON Article', 'description': 'This article has ld+json in head extra.' }</script>",
                 "<script type='application/ld+json'>{\n \"@context\": \"https://schema.org\",\n \"@type\": \"Article\",\n \"headline\": \"LD+JSON Article\",\n \"description\": \"This article has ld+json in head extra.\"\n }</script>",
+                "<link rel='icon' type='image/x-icon' href='/favicon.ico'>",
                 "<link rel='icon' href='/static/images/favicons/site-favicon-light.ico' type='image/x-icon' media='(prefers-color-scheme: light)'>",
                 "<link rel='icon' href='/static/images/favicons/site-favicon-dark.ico' type='image/x-icon' media='(prefers-color-scheme: dark)'>",
                 "<link rel='apple-touch-icon' href='/static/images/favicons/site-favicon-dark.png'>",

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -75,7 +75,7 @@ def test_json_loader_load_args_handles_head_extra_metadata(
     assert "head_extra" in metadata
     head_extra = metadata["head_extra"]
     assert isinstance(head_extra, list)
-    assert len(head_extra) == 8  # There are 8 elements in the head_extra list
+    assert len(head_extra) == 9  # There are 9 elements in the head_extra list
 
     assert " ".join(
         head_extra[0].strip().replace("\n", "").replace("\t", "").split()
@@ -112,6 +112,15 @@ def test_json_loader_load_args_handles_head_extra_metadata(
     assert " ".join(
         head_extra[3].strip().replace("\n", "").replace("\t", "").split()
     ) == " ".join(
+        ('<link rel="icon" type="image/x-icon" href="/favicon.ico">')
+        .strip()
+        .replace("\n", "")
+        .replace("\t", "")
+        .split()
+    )
+    assert " ".join(
+        head_extra[4].strip().replace("\n", "").replace("\t", "").split()
+    ) == " ".join(
         (
             '<link rel="icon" href="/static/images/favicons/site-favicon-light.ico"'
             + ' type="image/x-icon" media="(prefers-color-scheme: light)">'
@@ -122,7 +131,7 @@ def test_json_loader_load_args_handles_head_extra_metadata(
         .split()
     )
     assert " ".join(
-        head_extra[4].strip().replace("\n", "").replace("\t", "").split()
+        head_extra[5].strip().replace("\n", "").replace("\t", "").split()
     ) == " ".join(
         (
             '<link rel="icon" href="/static/images/favicons/site-favicon-dark.ico"'
@@ -134,7 +143,7 @@ def test_json_loader_load_args_handles_head_extra_metadata(
         .split()
     )
     assert " ".join(
-        head_extra[5].strip().replace("\n", "").replace("\t", "").split()
+        head_extra[6].strip().replace("\n", "").replace("\t", "").split()
     ) == " ".join(
         '<link rel="apple-touch-icon" href="/static/images/favicons/site-favicon-dark.png">'.strip()
         .replace("\n", "")
@@ -142,7 +151,7 @@ def test_json_loader_load_args_handles_head_extra_metadata(
         .split()
     )
     assert " ".join(
-        head_extra[6].strip().replace("\n", "").replace("\t", "").split()
+        head_extra[7].strip().replace("\n", "").replace("\t", "").split()
     ) == " ".join(
         '<script type="text/javascript" src="/static/scripts/theme-loader.js"></script>'.strip()
         .replace("\n", "")
@@ -150,7 +159,7 @@ def test_json_loader_load_args_handles_head_extra_metadata(
         .split()
     )
     assert " ".join(
-        head_extra[7].strip().replace("\n", "").replace("\t", "").split()
+        head_extra[8].strip().replace("\n", "").replace("\t", "").split()
     ) == " ".join(
         '<link rel="stylesheet" href="/static/styles/extra-styles.css">'.strip()
         .replace("\n", "")

--- a/tests/test_html_root_layout_builder.py
+++ b/tests/test_html_root_layout_builder.py
@@ -73,7 +73,6 @@ class TestHTMLRootLayoutBuilder:
         assert '<html lang="en">' in result
         assert '<meta charset="UTF-8">' in result
         assert "<title>Test Site</title>" in result
-        assert '<link rel="icon" type="image/x-icon" href="/favicon.ico">' in result
         assert '<link href="/static/styles/main.css" rel="stylesheet" />' in result
         assert "<body" in result
 
@@ -176,20 +175,18 @@ class TestHTMLRootLayoutBuilder:
         # Body attributes
         assert '<body id="main-page" class="home-page active">' in result
 
-    def test_get_doc_head_custom_styles_and_favicon(
+    def test_get_doc_head_custom_styles(
         self, builder: HTMLRootLayoutBuilder, minimal_render_args
     ):
         """Test custom stylesheet and favicon links"""
         result = builder.get_doc_head(
             minimal_render_args,
             styles_link="/custom/styles.css",
-            favicon_link='<link rel="icon" type="image/png" href="/custom-favicon.png">',
         )
         # Strip all newlines and extra spaces for easier assertions
         result = " ".join(result.split())
 
         assert '<link href="/custom/styles.css" rel="stylesheet" />' in result
-        assert '<link rel="icon" type="image/png" href="/custom-favicon.png">' in result
 
     def test_get_doc_head_empty_optional_fields(self, builder: HTMLRootLayoutBuilder):
         """Test that empty optional fields don't produce empty tags"""


### PR DESCRIPTION
This pull request updates how favicon links are managed in the static site generator. The favicon is no longer hardcoded in the HTML builder; instead, it is now included via the `head_extra` configuration, allowing for more flexible and customizable head content. Related tests and configuration files have been updated to reflect this change.

**Configuration and Metadata Handling:**

* Added the default favicon link (`<link rel='icon' type='image/x-icon' href='/favicon.ico'>`) to the `head_extra` list in `config.json`, making favicon management part of the site configuration instead of hardcoded in the HTML builder.
* Updated test configuration to include the favicon link in the `head_extra` array, ensuring test coverage for the new approach.

**HTML Builder and Rendering:**

* Removed the `favicon_link` parameter and its usage from the `HTMLRootLayoutBuilder.get_doc_head` method, so favicons (and other head elements) are now injected via `head_extra`.

**Testing Updates:**

* Updated tests in `test_data_loader.py` to expect the favicon link as part of the `head_extra` metadata, adjusting assertions and indices accordingly.
* Removed assertions expecting the favicon link to be hardcoded in the HTML output, and adjusted test names and logic to match the new configuration-driven approach.

**Miscellaneous:**

* Bumped the project version from `0.0.1a3` to `0.0.1a4` in `pyproject.toml`.